### PR TITLE
Mention the new kubecfg home

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool for managing complex enterprise Kubernetes environments as code.
 
-**Note: Effort on this project has moved to [ksonnet/kubecfg](https://github.com/ksonnet/kubecfg)** (a golang rewrite, hence I haven't just transferred this repo)
+**Note: Effort on this project has moved to [kubecfg/kubecfg](https://github.com/kubecfg/kubecfg)** (a golang rewrite, hence I haven't just transferred this repo)
 
 kubecfg allows you to express the patterns across your infrastructure
 and reuse these powerful "templates" across many services.  The more


### PR DESCRIPTION
ksonnet/kubecfg redirects to bitnami-labs/kubecfg which redirects to vmware-archive/kubecfg which has been archived with a textual link to the new kubecfg/kubecfg home.